### PR TITLE
Add support for PHP version 8 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3|^8.0",
+        "php": "^7.1.3 || ^8.0",
         "abellion/xenus": "^0.18.0",
         "illuminate/contracts": "^5.8 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0",
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "illuminate/container": "^5.8 || ^6.0 || ^7.0 || ^8.0",
-        "phpunit/phpunit": "^7.5|^8.0|^9.0",
+        "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
         "illuminate/config": "^5.8 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/events": "^5.8 || ^6.0 || ^7.0 || ^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
-        "abellion/xenus": "^0.17.0",
+        "php": "^7.1.3|^8.0",
+        "abellion/xenus": "^0.18.0",
         "illuminate/contracts": "^5.8 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/queue": "^5.8 || ^6.0 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.1.3",
-        "abellion/xenus": "^0.17.0",
+        "php": "^7.1.3|^8.0",
+        "abellion/xenus": "^0.18.0",
         "illuminate/contracts": "^5.8 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/queue": "^5.8 || ^6.0 || ^7.0 || ^8.0",
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "illuminate/container": "^5.8 || ^6.0 || ^7.0 || ^8.0",
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^7.5|^8.0|^9.0",
         "illuminate/config": "^5.8 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/events": "^5.8 || ^6.0 || ^7.0 || ^8.0"
     },

--- a/tests/Support/SetupTestsHooks.php
+++ b/tests/Support/SetupTestsHooks.php
@@ -9,7 +9,7 @@ trait SetupTestsHooks
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         foreach ($this->setup ?? [] as $setup) {
             call_user_func([$this, $setup]);
@@ -21,7 +21,7 @@ trait SetupTestsHooks
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach ($this->tearDown ?? [] as $tearDown) {
             call_user_func([$this, $tearDown]);


### PR DESCRIPTION
Hello,
This is a PR that adds PHP8 support in composer.json
Also added return type for `setUp` and `tearDown` methods for the tests, so they match the declaration in recent versions of PHPUnit. Added explicit support in composer.json for the more recent versions of PHPUnit as well.
I ran the test suite on PHP7.4 and PHP8 with PHPUnit 9.4.5. Both ran perfectly.